### PR TITLE
calendar external links

### DIFF
--- a/_includes/sidebars/event.html
+++ b/_includes/sidebars/event.html
@@ -13,7 +13,14 @@
     Ends: 
     <br />
     {{ page.ends_at | date:"%b %-d, %y at %I:%M%P" }}
+    <br />
   </div>
+  {% if page.external_link %}
+    <div style="margin-top: 15px;">
+      Link:
+      <a href={{ page.external_link }}>Click Here</a>
+    </div>
+  {% endif %}
 
   {% if page.additional_info %}
     <br />

--- a/_posts/events/2017-08-28-kick_off.md
+++ b/_posts/events/2017-08-28-kick_off.md
@@ -2,9 +2,10 @@
 layout: event
 sidebar: event
 title: "March On Milwaukee 50th Anniversary Kick-Off"
-starts_at: "2017-08-28T10:30Z"
-ends_at: "2017-08-29T01:00Z"
+starts_at: "2017-08-28T17:30Z"
+ends_at: "2017-08-28T19:30Z"
 location: "City Hall"
+external_link: "https://www.facebook.com/events/855601631264600/"
 ---
 
 This event will serve as the kick-off to 200 Nights of Freedom, emphasizing the historical significance and on-going relevance of the open housing marches and their progeny. The kick-off welcomes local, regional and statewide contributors in an effort to share the 200-day calendar of events with attendees. A key feature of this event will be the recognizing of accomplishments by March On Milwaukee leaders, many of whom are now community elders.


### PR DESCRIPTION
copied the inline style, since it doesn't look like the classes on the elements here have styles associated with them

Wasn't sure on copy, but this is what it looks like:

![image](https://user-images.githubusercontent.com/1430443/29684577-21201c3a-88d8-11e7-8242-99848413c55f.png)

Also updated the kickoff event info since it didn't seem correct?