### PR TITLE
Fix calendar stuff

### DIFF
--- a/_includes/sidebars/event.html
+++ b/_includes/sidebars/event.html
@@ -7,12 +7,20 @@
   <div class="start">
     Starts: 
     <br />
-    {{ page.starts_at | date:"%b %-d, %Y at %I:%M%P" }}
+    {% if page.starts_at | date:"%H" == "0" %}
+    {{ page.starts_at | date:"%b %-d, %Y at TBD" }}
+    {% else %}
+      {{ page.starts_at | date:"%b %-d, %Y at %I:%M%P" }}
+    {% endif %}
   </div>
   <div class="end" style="margin-top: 15px;">
     Ends: 
     <br />
-    {{ page.ends_at | date:"%b %-d, %y at %I:%M%P" }}
+    {% if page.ends_at | date:"%H" == "0" %}
+    {{ page.ends_at | date:"%b %-d, %Y at TBD" }}
+    {% else %}
+      {{ page.ends_at | date:"%b %-d, %Y at %I:%M%P" }}
+    {% endif %}
     <br />
   </div>
   {% if page.external_link %}

--- a/_posts/events/2017-09-06-crossing-the-line-racine.md
+++ b/_posts/events/2017-09-06-crossing-the-line-racine.md
@@ -2,7 +2,7 @@
 layout: event
 sidebar: event
 title: "'Crossing the Line' in Racine"
-starts_at: "2017-09-06T9:00"
+starts_at: "2017-09-06T09:00"
 ends_at: "2017-09-06T20:00"
 location: "Racine Public Library (75 7th St, Racine, WI)"
 external_link: "https://www.wisconsinhistory.org/calendar/series/43/crossing-the-line"

--- a/_posts/events/2017-09-09-standup-to-antimuslim-hate.md
+++ b/_posts/events/2017-09-09-standup-to-antimuslim-hate.md
@@ -2,7 +2,7 @@
 layout: event
 sidebar: event
 title: "Stand Up to Anti-Muslim Hate"
-starts_at: "2017-09-09T8:00"
+starts_at: "2017-09-09T08:00"
 ends_at: "2017-09-09T10:00"
 location: "Milwaukee Federal Courthouse (315 E. Wisconsin Ave)"
 external_link: "https://www.facebook.com/events/1966493196908747/"

--- a/_posts/events/2017-09-13-crossing-the-line-princeton.md
+++ b/_posts/events/2017-09-13-crossing-the-line-princeton.md
@@ -2,8 +2,8 @@
 layout: event
 sidebar: event
 title: "'Crossing the Line' in Princeton"
-starts_at: "2017-09-13T10:00Z"
-ends_at: "2017-09-13T20:00Z"
+starts_at: "2017-09-13T10:00"
+ends_at: "2017-09-13T20:00"
 location: "Princeton Public Library (424 W Water St)"
 organization: "Princeton Public Library, Wisconsin Historical Society"
 ---

--- a/_posts/events/2017-09-22-creative-mornings.md
+++ b/_posts/events/2017-09-22-creative-mornings.md
@@ -2,8 +2,8 @@
 layout: event
 sidebar: event
 title: "CreativeMornings Milwaukee presents: Compassion"
-starts_at: "2017-09-22T08:30Z"
-ends_at: "2017-09-22T10:00Z"
+starts_at: "2017-09-22T08:30"
+ends_at: "2017-09-22T10:00"
 location: "TBD"
 organization: "Creative Mornings"
 ---

--- a/_posts/events/2017-09-23-art-justice-trail.md
+++ b/_posts/events/2017-09-23-art-justice-trail.md
@@ -2,8 +2,8 @@
 layout: event
 sidebar: event
 title: "Art & Justice Trail (Bronzeville Loop)"
-starts_at: "2017-09-23T9:00Z"
-ends_at: "2017-09-23T12:00Z"
+starts_at: "2017-09-23T09:00"
+ends_at: "2017-09-23T12:00"
 location: "Bronzeville"
 organization: "ZIP MKE, The Generosity Project, and Doors Open Milwaukee"
 link: "http://www.doorsopenmilwaukee.org/tours-2017/"

--- a/_posts/events/2017-09-24-art-justice-trail.md
+++ b/_posts/events/2017-09-24-art-justice-trail.md
@@ -2,8 +2,8 @@
 layout: event
 sidebar: event
 title: "Art & Justice Trail (Civil Rights Marches Tour)"
-starts_at: "2017-09-24T9:00Z"
-ends_at: "2017-09-24T12:00Z"
+starts_at: "2017-09-24T09:00"
+ends_at: "2017-09-24T12:00"
 location: "Downtown & near South Side"
 organization: "ZIP MKE, The Generosity Project, and Doors Open Milwaukee"
 link: "http://www.doorsopenmilwaukee.org/tours-2017/"

--- a/_posts/events/2017-09-25-crossing-the-line-oak-creek.md
+++ b/_posts/events/2017-09-25-crossing-the-line-oak-creek.md
@@ -2,8 +2,8 @@
 layout: event
 sidebar: event
 title: "'Crossing the Line' in Oak Creek"
-starts_at: "2017-09-25T9:00Z"
-ends_at: "2017-09-25T20:00Z"
+starts_at: "2017-09-25T09:00"
+ends_at: "2017-09-25T20:00"
 location: "Oak Creek Public Library (8040 S 6th St, Oak Creek, WI)"
 organization: "Oak Creek Public Library, Wisconsin Historical Society"
 ---

--- a/_posts/events/2017-09-28-crossingtheline-centrallibrary-closing.md
+++ b/_posts/events/2017-09-28-crossingtheline-centrallibrary-closing.md
@@ -2,7 +2,7 @@
 layout: event
 sidebar: event
 title: "’Crossing the Line’ at Central Library"
-starts_at: "2017–09-28T9:00"
+starts_at: "2017-09-28T09:00"
 ends_at: "2017-09-28T18:00"
 location: "Milwaukee Public Library Central Branch (814 W Wisconsin Ave)"
 organization: "Milwaukee Public Library, Wisconsin Historical Society"

--- a/_posts/events/2017-09-28-hankaaronstatetrail-publicartwalk.md
+++ b/_posts/events/2017-09-28-hankaaronstatetrail-publicartwalk.md
@@ -2,7 +2,7 @@
 layout: event
 sidebar: event
 title: "Public Art Walk on the Hank Aaron State Trail"
-starts_at: "2017–09-28T17:15"
+starts_at: "2017-09-28T17:15"
 ends_at: "2017-09-28T19:00"
 location: "Begins at the Sigma Group (1300 W. Canal St.)"
 organization: "Menomonee Valley Partners"

--- a/_posts/events/2017-10-03-crossingtheline-princeton-closing.md
+++ b/_posts/events/2017-10-03-crossingtheline-princeton-closing.md
@@ -2,8 +2,8 @@
 layout: event
 sidebar: event
 title: "'Crossing the Line' in Princeton"
-starts_at: "2017-10-03T9:00Z"
-ends_at: "2017-10-03T21:00Z"
+starts_at: "2017-10-03T09:00"
+ends_at: "2017-10-03T21:00"
 location: "Princeton Public Library (424 W Water St)"
 organization: "Princeton Public Library, Wisconsin Historical Society"
 ---

--- a/_posts/events/2017-10-04-crossingtheline-lakemills.md
+++ b/_posts/events/2017-10-04-crossingtheline-lakemills.md
@@ -2,7 +2,7 @@
 layout: event
 sidebar: event
 title: "’Crossing the Line’ in Lake Mills"
-starts_at: "2017-10-04T9:00"
+starts_at: "2017-10-04T09:00"
 ends_at: "2017-10-04T21:00"
 location: "L. D. Fargo Public Library, Lake Mills (120 E Madison St, Lake Mills, WI)"
 external_link: "https://www.wisconsinhistory.org/calendar/series/43/crossing-the-line"

--- a/_posts/events/2017-10-04-housinginmke-leagueofwomenvoters.md
+++ b/_posts/events/2017-10-04-housinginmke-leagueofwomenvoters.md
@@ -2,7 +2,7 @@
 layout: event
 sidebar: event
 title: "Housing in MKE: Evictions, Race Relations and Policy"
-starts_at: "2017–10-04T17:30"
+starts_at: "2017-10-04T17:30"
 ends_at: "2017-10-04T20:00"
 location: "TBA"
 organization: "League of Women Voters Milwaukee County"

--- a/_posts/events/2017-10-04-mkesupports-people-in-prisons.md
+++ b/_posts/events/2017-10-04-mkesupports-people-in-prisons.md
@@ -2,8 +2,8 @@
 layout: event
 sidebar: event
 title: "Milwaukee Supports People in Prisons"
-starts_at: "2017–10-04T18:00"
-ends_at: "2017-10-04T19:30"
+starts_at: "2017-10-04T18:00"
+ends_at: "2018-10-04T19:30"
 location: "Center Street Library (2727 W. Fond Du Lac Ave.)"
 organization: "Black and Pink Milwaukee"
 external_link: "https://www.facebook.com/MKEBlackandPink/"

--- a/_posts/events/2017-10-17-crossingtheline-oakcreek-closing.md
+++ b/_posts/events/2017-10-17-crossingtheline-oakcreek-closing.md
@@ -2,8 +2,8 @@
 layout: event
 sidebar: event
 title: "'Crossing the Line' in Oak Creek"
-starts_at: "2017-10-17T9:00Z"
-ends_at: "2017-10-17T20:00Z"
+starts_at: "2017-10-17T09:00"
+ends_at: "2017-10-17T20:00"
 location: "Oak Creek Public Library (8040 S 6th St, Oak Creek, WI)"
 organization: "Oak Creek Public Library, Wisconsin Historical Society"
 ---

--- a/_posts/events/2017-10-19-crossingtheline-mchs-opening.md
+++ b/_posts/events/2017-10-19-crossingtheline-mchs-opening.md
@@ -2,8 +2,8 @@
 layout: event
 sidebar: event
 title: "'Crossing the Line' at Milwaukee County Historical Society"
-starts_at: "2017-10-19T9:30Z"
-ends_at: "2017-10-19T17:00Z"
+starts_at: "2017-10-19T09:30"
+ends_at: "2017-10-19T17:00"
 location: "Milwaukee County Historical Society (910 N Old World Third St)"
 organization: "Milwaukee County Historical Society, Wisconsin Historical Society"
 ---

--- a/_posts/events/2017-10-24-crossingtheline-lakemills-closing.md
+++ b/_posts/events/2017-10-24-crossingtheline-lakemills-closing.md
@@ -2,7 +2,7 @@
 layout: event
 sidebar: event
 title: "’Crossing the Line’ in Lake Mills"
-starts_at: "2017-10-24T9:00"
+starts_at: "2017-10-24T09:00"
 ends_at: "2017-10-24T21:00"
 location: "L. D. Fargo Public Library, Lake Mills (120 E Madison St, Lake Mills, WI)"
 external_link: "https://www.wisconsinhistory.org/calendar/series/43/crossing-the-line"

--- a/_posts/events/2017-10-25-crossingtheline-uwwaukesha-opening.md
+++ b/_posts/events/2017-10-25-crossingtheline-uwwaukesha-opening.md
@@ -2,8 +2,8 @@
 layout: event
 sidebar: event
 title: "'Crossing the Line' in Waukesha"
-starts_at: "2017-10-25T9:00Z"
-ends_at: "2017-10-25T17:00Z"
+starts_at: "2017-10-25T09:00"
+ends_at: "2017-10-25T17:00"
 location: "UW-Waukesha (1500 N University Dr)"
 organization: "UW-Waukesha, Wisconsin Historical Society"
 ---

--- a/_posts/events/2017-11-07-crossingtheline-mchs-closing.md
+++ b/_posts/events/2017-11-07-crossingtheline-mchs-closing.md
@@ -2,8 +2,8 @@
 layout: event
 sidebar: event
 title: "'Crossing the Line' at Milwaukee County Historical Society"
-starts_at: "2017-11-07T9:30Z"
-ends_at: "2017-11-07T17:00Z"
+starts_at: "2017-11-07T09:30"
+ends_at: "2017-11-07T17:00"
 location: "Milwaukee County Historical Society (910 N Old World Third St)"
 organization: "Milwaukee County Historical Society, Wisconsin Historical Society"
 ---

--- a/_posts/events/2017-11-08-evicted-discussion-villard.md
+++ b/_posts/events/2017-11-08-evicted-discussion-villard.md
@@ -2,7 +2,7 @@
 layout: event
 sidebar: event
 title: "Evicted Book Discussion"
-starts_at: "2017–11-08T18:30"
+starts_at: "2017-11-08T18:30"
 ends_at: "2017-11-08T19:30"
 location: "Villard Square Branch Library (5190 N 35th St)"
 organization: "Milwaukee Public Library"

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -83,7 +83,7 @@ new Vue({
       var daysInMonth = endOfMonth.getDate();
       var offset = beginningOfMonth.getDay();
       var date = ((week * 7) + day - offset + 1);
-      if((week === 0 && day < offset) || (day + (week * 7) > (daysInMonth + offset - 1))) {
+      if((week === 0 && day < offset) || (day + (week * 7) > (daysInMonth + offset))) {
         if(this.display == "month") {
           return "";
         } else {

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -229,6 +229,7 @@ new Vue({
     nextWeek: function() {
       this.currentWeek++;
       if(this.currentWeek > this.weeks) {
+        // if the end of this week is already the next month, start on the second week of the next month
         if(this.dateO(this.currentMonth, this.currentWeek - 1, 6).getMonth() > this.currentMonth ) {
           this.currentWeek = 2;
         } else {

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -36,7 +36,7 @@ new Vue({
     today: new Date(),
     currentMonth: new Date().getMonth(),
     currentYear: new Date().getFullYear(),
-    display: "month",
+    display: "week",
     currentWeek: Math.ceil(new Date().getDate() / 7)
   },
   created: function() {

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -37,7 +37,7 @@ new Vue({
     currentMonth: new Date().getMonth(),
     currentYear: new Date().getFullYear(),
     display: "month",
-    currentWeek: parseInt((new Date().getDate() + (new Date(new Date().getFullYear(), new Date().getMonth(), 1).getDay())) / 7) + 1
+    currentWeek: Math.ceil(new Date().getDate() / 7)
   },
   created: function() {
     document.addEventListener("keydown", function(e) {
@@ -146,7 +146,7 @@ new Vue({
     },
     goToToday: function() {
       this.goToMonth(this.today.getMonth(), this.today.getFullYear())
-      this.currentWeek = parseInt((new Date().getDate() + (new Date(new Date().getFullYear(), new Date().getMonth(), 1).getDay())) / 7) + 1;
+      this.currentWeek = Math.ceil(this.today.getDate() / 7);
     },
     eventsOnDay: function(date) {
       var today = new Date(this.currentYear, this.currentMonth, date);
@@ -203,7 +203,7 @@ new Vue({
     displayWeek: function() {
       this.display = "week";
       if(this.today.getMonth() == this.currentMonth) {
-        this.currentWeek = parseInt((new Date().getDate() + (new Date(new Date().getFullYear(), new Date().getMonth(), 1).getDay())) / 7);
+        this.currentWeek = Math.ceil(this.today.getDate() / 7);
       } else {
         this.currentWeek = 1;
       }
@@ -224,14 +224,18 @@ new Vue({
     },
     nextWeek: function() {
       this.currentWeek++;
-      if(this.currentWeek > (this.weeks - 1)) {
-        this.currentWeek = 1;
+      if(this.currentWeek > this.weeks) {
+        if(this.dateO(this.currentMonth, this.currentWeek - 1, 6).getMonth() > this.currentMonth ) {
+          this.currentWeek = 2;
+        } else {
+          this.currentWeek = 1;
+        }
         this.nextMonth();
       }
     },
     previousWeek: function() {
       this.currentWeek--;
-      if(this.currentWeek <= 0) {
+      if(this.currentWeek < 0) {
         this.previousMonth();
         this.currentWeek = this.weeks - 1;
       }

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -3,7 +3,11 @@ Vue.component('weekday', {
   props: ['date', 'events'],
   methods: {
     starting: function(event) {
-      return this.formatDate(event.starts_at, "h:mm a");
+      if(event.starts_at.hour() == 0) {
+        return "TBD";
+      } else {
+        return this.formatDate(event.starts_at, "h:mm a");
+      }
     },
     formatDate: function(date, format) {
       var rawDate = new Date(date);

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -36,7 +36,7 @@ new Vue({
     today: new Date(),
     currentMonth: new Date().getMonth(),
     currentYear: new Date().getFullYear(),
-    display: "week",
+    display: "month",
     currentWeek: parseInt((new Date().getDate() + (new Date(new Date().getFullYear(), new Date().getMonth(), 1).getDay())) / 7) + 1
   },
   created: function() {


### PR DESCRIPTION
Closes #15, #14 

For #14, if an event start or end time is 00:00, it will show TBD.

I did not do #16, as I wasn't sure how defaulting to month would affect mobile (cc @nickgartmann)

As mentioned in Slack, the dates for events can't use curly quotes, long dashes, and has to be in `09:00` format.